### PR TITLE
Support optional filters in yaml config

### DIFF
--- a/config.go
+++ b/config.go
@@ -94,6 +94,12 @@ func LoadConfig(path string) (*Config, error) {
 }
 
 func (c *Config) compileFilterRegexps() error {
+	if len(c.Filters) == 0 {
+		c.Filters = []*Filter{
+			{Value: ".*", Type: "name"},
+		}
+	}
+
 	for i, filter := range c.Filters {
 		re, err := regexp.Compile(filter.Value)
 		if err != nil {


### PR DESCRIPTION
Hey 👋 I just discovered this repo thanks to @martelogan. It's great and saved me a lot of time trying to figure out how to make the remux work.

When trying to setup the server based on the readme, I tried to remove the filters configuration and expected it to return all tracks but no tracks were returned. It looks like the track building part assumed the presence of filters. I added a default in the config to set `{Value: ".*", Type: "name"}` when trying to compile the regexes and no filters are provided. This will return all the tracks. 

While updating the tests, I also updated the filter types in the valid configuration to match the filter types expected in provider.go


