### PR TITLE
fix tracks processing when tags are empty

### DIFF
--- a/config.go
+++ b/config.go
@@ -94,12 +94,6 @@ func LoadConfig(path string) (*Config, error) {
 }
 
 func (c *Config) compileFilterRegexps() error {
-	if len(c.Filters) == 0 {
-		c.Filters = []*Filter{
-			{Value: ".*", Type: "name"},
-		}
-	}
-
 	for i, filter := range c.Filters {
 		re, err := regexp.Compile(filter.Value)
 		if err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -98,13 +98,9 @@ maxStreams: 10
 		assert.Equal(t, "iptvserver:8080", config.ServerAddress)
 		assert.True(t, config.UseFFMPEG)
 		assert.Equal(t, 10, config.MaxStreams)
-		assert.Len(t, config.Filters, 1)
-		assert.Equal(t, ".*", config.Filters[0].Value)
-		assert.Equal(t, "name", config.Filters[0].Type)
-		assert.NotNil(t, config.Filters[0].GetRegexp())
+		assert.Len(t, config.Filters, 0)
 		assert.Equal(t, 2*time.Hour, config.RefreshInterval)
 	})
-
 
 	// Test with invalid regular expression
 	t.Run("Invalid Regular Expression", func(t *testing.T) {


### PR DESCRIPTION
Currently, when no filters are defined, one filter with `tvg-name=".*"` regex is added programmatically.

Since my IPTV subscription doesn't have this tag, when filters aren't specified, it doesn't process tracks at all.

This PR makes filters truly optional